### PR TITLE
Map markers

### DIFF
--- a/client/src/components/MapIcons.js
+++ b/client/src/components/MapIcons.js
@@ -2,7 +2,7 @@ import eventSVG from "../media/map-marker-event.svg"
 import sellerSVG from "../media/map-marker-seller.svg"
 import L from "leaflet"
 
-const iconSize = new L.Point(30, 50)
+const iconSize = new L.Point(25, 50)
 
 const eventMarker = new L.Icon({
   iconUrl: eventSVG,
@@ -28,4 +28,22 @@ const sellerMarker = new L.Icon({
   className: "leaflet-div-icon",
 })
 
-export { eventMarker, sellerMarker }
+const sellerMarkerHTML = new L.divIcon({
+  className: "marker-seller",
+  html: `<svg aria-hidden="false" focusable="false" data-prefix="fas" data-icon="map-marker" class="svg-inline--fa fa-map-marker fa-w-12" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+  <path fill="currentColor" stroke="black" stroke-width="0" stroke-linejoin="round" stroke-dasharray="2,2" d=" M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
+  <text x="50%" y="45%" text-anchor="middle" fill="white" font-family="Arial" font-size="220px" dy=".3em">T</text>
+</svg>`,
+  iconSize: iconSize,
+})
+
+const eventMarkerHTML = new L.divIcon({
+  className: "marker-event",
+  html: `<svg aria-hidden="false" focusable="false" data-prefix="fas" data-icon="map-marker" class="svg-inline--fa fa-map-marker fa-w-12" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+  <path fill="currentColor" stroke="black" stroke-width="0" stroke-linejoin="round" stroke-dasharray="2,2" d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
+  <text x="50%" y="45%" text-anchor="middle" fill="white" font-family="Arial" font-size="220px" dy=".3em">R</text>
+</svg>`,
+  iconSize: iconSize,
+})
+
+export { eventMarker, sellerMarker, sellerMarkerHTML, eventMarkerHTML }

--- a/client/src/components/MapIcons.js
+++ b/client/src/components/MapIcons.js
@@ -2,7 +2,7 @@ import eventSVG from "../media/map-marker-event.svg"
 import sellerSVG from "../media/map-marker-seller.svg"
 import L from "leaflet"
 
-const iconSize = new L.Point(30, 45)
+const iconSize = new L.Point(30, 50)
 
 const eventMarker = new L.Icon({
   iconUrl: eventSVG,

--- a/client/src/components/MapIcons.js
+++ b/client/src/components/MapIcons.js
@@ -1,0 +1,31 @@
+import eventSVG from "../media/map-marker-event.svg"
+import sellerSVG from "../media/map-marker-seller.svg"
+import L from "leaflet"
+
+const iconSize = new L.Point(30, 45)
+
+const eventMarker = new L.Icon({
+  iconUrl: eventSVG,
+  iconRetinaUrl: eventSVG,
+  iconAnchor: null,
+  popupAnchor: null,
+  shadowUrl: null,
+  shadowSize: null,
+  shadowAnchor: null,
+  iconSize: iconSize,
+  className: "leaflet-div-icon",
+})
+
+const sellerMarker = new L.Icon({
+  iconUrl: sellerSVG,
+  iconRetinaUrl: sellerSVG,
+  iconAnchor: null,
+  popupAnchor: null,
+  shadowUrl: null,
+  shadowSize: null,
+  shadowAnchor: null,
+  iconSize: iconSize,
+  className: "leaflet-div-icon",
+})
+
+export { eventMarker, sellerMarker }

--- a/client/src/components/MapIcons.js
+++ b/client/src/components/MapIcons.js
@@ -35,6 +35,7 @@ const sellerMarkerHTML = new L.divIcon({
   <text x="50%" y="45%" text-anchor="middle" fill="white" font-family="Arial" font-size="220px" dy=".3em">T</text>
 </svg>`,
   iconSize: iconSize,
+  popupAnchor: [-5, -10],
 })
 
 const eventMarkerHTML = new L.divIcon({
@@ -44,6 +45,7 @@ const eventMarkerHTML = new L.divIcon({
   <text x="50%" y="45%" text-anchor="middle" fill="white" font-family="Arial" font-size="220px" dy=".3em">R</text>
 </svg>`,
   iconSize: iconSize,
+  popupAnchor: [-5, -10],
 })
 
 export { eventMarker, sellerMarker, sellerMarkerHTML, eventMarkerHTML }

--- a/client/src/components/MapPage.css
+++ b/client/src/components/MapPage.css
@@ -12,3 +12,21 @@
   padding-top: 10px;
   height: 100%;
 }
+
+.marker-event {
+  color: rgb(0, 143, 0);
+}
+
+.marker-event:hover,
+.marker-event:active {
+  color: rgb(124, 231, 124);
+}
+
+.marker-seller {
+  color: rgb(17, 17, 110);
+}
+
+.marker-seller:hover,
+.marker-seller:active {
+  color: rgb(154, 154, 230);
+}

--- a/client/src/components/MapPage.css
+++ b/client/src/components/MapPage.css
@@ -14,7 +14,7 @@
 }
 
 .marker-event {
-  color: rgb(0, 143, 0);
+  color: rgb(70, 143, 3);
 }
 
 .marker-event:hover,
@@ -29,4 +29,8 @@
 .marker-seller:hover,
 .marker-seller:active {
   color: rgb(154, 154, 230);
+}
+
+.popup-card {
+  border-width: 0;
 }

--- a/client/src/components/MapPage.css
+++ b/client/src/components/MapPage.css
@@ -1,3 +1,8 @@
+.leaflet-div-icon {
+  background: transparent;
+  border: none;
+}
+
 .leaflet-container {
   width: 100%;
   height: 90%;

--- a/client/src/components/MapPage.js
+++ b/client/src/components/MapPage.js
@@ -1,9 +1,10 @@
 import "./MapPage.css"
 import { useRef, useEffect, useState } from "react"
-import { MapContainer, TileLayer, Marker, useMapEvents } from "react-leaflet"
+import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from "react-leaflet"
 import MapBottomPanel from "./MapBottomPanel"
 import Row from "react-bootstrap/Row"
 import Col from "react-bootstrap/Col"
+import Card from "react-bootstrap/Card"
 import Button from "react-bootstrap/Button"
 import EventPage from "./EventPage"
 import SellerPage from "./SellerPage"
@@ -79,7 +80,7 @@ const sellers = [
   },
 ]
 
-const MapInstance = ({ setMapBounds, setMapCenter }) => {
+const MapInstance = ({ setMapBounds, setMapCenter, setMapInstance }) => {
   const map = useMapEvents({
     load: () => {
       setMapBounds(map.getBounds())
@@ -95,6 +96,8 @@ const MapInstance = ({ setMapBounds, setMapCenter }) => {
     },
   })
 
+  setMapInstance(map)
+
   return null
 }
 
@@ -103,6 +106,7 @@ const MapPage = () => {
   const [totalVisible, setTotalVisible] = useState(0)
   const [mapCenter, setMapCenter] = useState([61.59229896416896, 27.256461799773678])
   const [mapBounds, setMapBounds] = useState(null)
+  const [mapInstance, setMapInstance] = useState(null)
   const [openedPage, setOpenedPage] = useState(null)
 
   const firstRender = useRef(true)
@@ -142,6 +146,10 @@ const MapPage = () => {
     setOpenedPage(page)
   }
 
+  const getMapInstance = (map) => {
+    setMapInstance(map)
+  }
+
   const scrollIntoPanel = () => {
     bottomPanelRef.current.scrollIntoView({
       behavior: "smooth",
@@ -150,16 +158,33 @@ const MapPage = () => {
 
   const markEvents = events.map((event, index) => (
     <Marker
-      className="marker-event"
       position={event.location}
       key={index}
       icon={eventMarkerHTML}
       eventHandlers={{
         click: (e) => {
-          setOpenedPage(EventPage({ event: event, closePage: handleClosePage }))
+          mapInstance.flyTo(e.latlng, mapInstance.getZoom())
         },
       }}
-    />
+    >
+      <Popup className="map-popup" autoPan={false}>
+        <Card className="text-center popup-card">
+          Noutotilaisuus (REKO) <br />
+          {event.address} <br />
+          10.7 <br />
+          18.00-18.30 <br />
+        </Card>
+        <Button
+          className="btn btn-primary btn-sm popup-button"
+          variant="success"
+          onClick={() =>
+            setOpenedPage(EventPage({ event: event, closePage: handleClosePage }))
+          }
+        >
+          Siirry tilaisuuteen
+        </Button>
+      </Popup>
+    </Marker>
   ))
 
   const markSellers = sellers.map((seller, index) => (
@@ -169,10 +194,24 @@ const MapPage = () => {
       icon={sellerMarkerHTML}
       eventHandlers={{
         click: (e) => {
-          setOpenedPage(SellerPage({ seller: seller, closePage: handleClosePage }))
+          mapInstance.flyTo(e.latlng, mapInstance.getZoom())
         },
       }}
-    />
+    >
+      <Popup autoPan={false}>
+        {seller.name} <br />
+        {seller.address} <br />
+        <Button
+          className="btn btn-primary btn-sm"
+          variant="success"
+          onClick={() =>
+            setOpenedPage(SellerPage({ seller: seller, closePage: handleClosePage }))
+          }
+        >
+          Tuottajan sivulle
+        </Button>
+      </Popup>
+    </Marker>
   ))
 
   return openedPage ? (
@@ -195,6 +234,7 @@ const MapPage = () => {
         <MapInstance
           setMapBounds={handleBoundsChange}
           setMapCenter={handleCenterChange}
+          setMapInstance={getMapInstance}
         />
         {markEvents}
         {markSellers}

--- a/client/src/components/MapPage.js
+++ b/client/src/components/MapPage.js
@@ -7,8 +7,7 @@ import Col from "react-bootstrap/Col"
 import Button from "react-bootstrap/Button"
 import EventPage from "./EventPage"
 import SellerPage from "./SellerPage"
-import L from "leaflet"
-import marker from "../media/map-marker-solid.svg"
+import { eventMarker, sellerMarker } from "./MapIcons"
 
 const events = [
   {
@@ -149,31 +148,11 @@ const MapPage = () => {
     })
   }
 
-  const mapMarker = new L.Icon({
-    iconUrl: marker,
-    iconRetinaUrl: marker,
-    iconAnchor: null,
-    popupAnchor: null,
-    shadowUrl: null,
-    shadowSize: null,
-    shadowAnchor: null,
-    iconSize: new L.Point(30, 45),
-    className: "leaflet-div-icon",
-  })
-
-  const icon = L.divIcon({
-    className: "marker-seller",
-    html: `<img src=${marker} />`,
-    iconSize: [40, 40],
-    iconAnchor: [12, 24],
-    popupAnchor: [7, -16],
-  })
-
   const markEvents = events.map((event, index) => (
     <Marker
       position={event.location}
       key={index}
-      icon={icon}
+      icon={eventMarker}
       eventHandlers={{
         click: (e) => {
           setOpenedPage(EventPage({ event: event, closePage: handleClosePage }))
@@ -186,6 +165,7 @@ const MapPage = () => {
     <Marker
       position={seller.location}
       key={index}
+      icon={sellerMarker}
       eventHandlers={{
         click: (e) => {
           setOpenedPage(SellerPage({ seller: seller, closePage: handleClosePage }))

--- a/client/src/components/MapPage.js
+++ b/client/src/components/MapPage.js
@@ -7,7 +7,7 @@ import Col from "react-bootstrap/Col"
 import Button from "react-bootstrap/Button"
 import EventPage from "./EventPage"
 import SellerPage from "./SellerPage"
-import { eventMarker, sellerMarker } from "./MapIcons"
+import { sellerMarkerHTML, eventMarkerHTML } from "./MapIcons"
 
 const events = [
   {
@@ -150,28 +150,29 @@ const MapPage = () => {
 
   const markEvents = events.map((event, index) => (
     <Marker
+      className="marker-event"
       position={event.location}
       key={index}
-      icon={eventMarker}
+      icon={eventMarkerHTML}
       eventHandlers={{
         click: (e) => {
           setOpenedPage(EventPage({ event: event, closePage: handleClosePage }))
         },
       }}
-    ></Marker>
+    />
   ))
 
   const markSellers = sellers.map((seller, index) => (
     <Marker
       position={seller.location}
       key={index}
-      icon={sellerMarker}
+      icon={sellerMarkerHTML}
       eventHandlers={{
         click: (e) => {
           setOpenedPage(SellerPage({ seller: seller, closePage: handleClosePage }))
         },
       }}
-    ></Marker>
+    />
   ))
 
   return openedPage ? (

--- a/client/src/components/MapPage.js
+++ b/client/src/components/MapPage.js
@@ -7,6 +7,8 @@ import Col from "react-bootstrap/Col"
 import Button from "react-bootstrap/Button"
 import EventPage from "./EventPage"
 import SellerPage from "./SellerPage"
+import L from "leaflet"
+import marker from "../media/map-marker-solid.svg"
 
 const events = [
   {
@@ -147,10 +149,31 @@ const MapPage = () => {
     })
   }
 
+  const mapMarker = new L.Icon({
+    iconUrl: marker,
+    iconRetinaUrl: marker,
+    iconAnchor: null,
+    popupAnchor: null,
+    shadowUrl: null,
+    shadowSize: null,
+    shadowAnchor: null,
+    iconSize: new L.Point(30, 45),
+    className: "leaflet-div-icon",
+  })
+
+  const icon = L.divIcon({
+    className: "marker-seller",
+    html: `<img src=${marker} />`,
+    iconSize: [40, 40],
+    iconAnchor: [12, 24],
+    popupAnchor: [7, -16],
+  })
+
   const markEvents = events.map((event, index) => (
     <Marker
       position={event.location}
       key={index}
+      icon={icon}
       eventHandlers={{
         click: (e) => {
           setOpenedPage(EventPage({ event: event, closePage: handleClosePage }))

--- a/client/src/media/map-marker-event.svg
+++ b/client/src/media/map-marker-event.svg
@@ -1,0 +1,4 @@
+<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="map-marker" class="svg-inline--fa fa-map-marker fa-w-12" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+    <path fill="#f7e974" stroke="black" stroke-width="10" stroke-linejoin="round" stroke-dasharray="1,2" d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
+    <text x="50%" y="45%" text-anchor="middle" fill="black" font-family="Arial" font-size="220px" dy=".3em">R</text>
+</svg>

--- a/client/src/media/map-marker-event.svg
+++ b/client/src/media/map-marker-event.svg
@@ -1,4 +1,4 @@
 <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="map-marker" class="svg-inline--fa fa-map-marker fa-w-12" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-    <path fill="#f7e974" stroke="black" stroke-width="10" stroke-linejoin="round" stroke-dasharray="1,2" d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
+    <path fill="#f7e974" stroke="black" stroke-width="5" stroke-linejoin="round" stroke-dasharray="2,2" d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
     <text x="50%" y="45%" text-anchor="middle" fill="black" font-family="Arial" font-size="220px" dy=".3em">R</text>
 </svg>

--- a/client/src/media/map-marker-seller.svg
+++ b/client/src/media/map-marker-seller.svg
@@ -1,4 +1,4 @@
 <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="map-marker" class="svg-inline--fa fa-map-marker fa-w-12" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-    <path fill="#cbe4f2" stroke="black" stroke-width="10" stroke-linejoin="round" stroke-dasharray="1,2" d=" M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
+    <path fill="#cbe4f2" stroke="black" stroke-width="5" stroke-linejoin="round" stroke-dasharray="2,2" d=" M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
     <text x="50%" y="45%" text-anchor="middle" fill="black" font-family="Arial" font-size="220px" dy=".3em">T</text>
 </svg>

--- a/client/src/media/map-marker-seller.svg
+++ b/client/src/media/map-marker-seller.svg
@@ -1,0 +1,4 @@
+<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="map-marker" class="svg-inline--fa fa-map-marker fa-w-12" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+    <path fill="#cbe4f2" stroke="black" stroke-width="10" stroke-linejoin="round" stroke-dasharray="1,2" d=" M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
+    <text x="50%" y="45%" text-anchor="middle" fill="black" font-family="Arial" font-size="220px" dy=".3em">T</text>
+</svg>

--- a/client/src/media/map-marker-solid.svg
+++ b/client/src/media/map-marker-solid.svg
@@ -1,3 +1,0 @@
-<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="map-marker" class="svg-inline--fa fa-map-marker fa-w-12" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-    <path fill="currentColor" d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
-</svg>

--- a/client/src/media/map-marker-solid.svg
+++ b/client/src/media/map-marker-solid.svg
@@ -1,0 +1,3 @@
+<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="map-marker" class="svg-inline--fa fa-map-marker fa-w-12" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+    <path fill="currentColor" d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0z"></path>
+</svg>


### PR DESCRIPTION
Distinct markers for events and sellers.

It turns out we can style an svg leaflet marker with external CSS as long as it is defined as an html property of Leaflet.divIcon with the correct class. In summary: map markers can be styled in MapPage.css and they also accept :hover and :active selectors.

I've also changed map behavior so that clicking on a marker centers the map on the marker and opens a popup with a brief description and link to the related page. This can be changed back, but I thought it's more mobile-appropriate: it's easier to explore locations on the map and misclicks don't require the user to navigate back to the map.