### PR TITLE
URL navigation

### DIFF
--- a/client/src/components/App.css
+++ b/client/src/components/App.css
@@ -10,6 +10,14 @@ body {
   background-color: white;
 }
 
-.custom-control-input:checked~.custom-control-label::before {
+.custom-control-input:checked ~ .custom-control-label::before {
   background-color: #28a745;
+}
+
+a {
+  color: currentColor;
+}
+
+Link {
+  color: currentColor;
 }

--- a/client/src/components/AppBuyer.js
+++ b/client/src/components/AppBuyer.js
@@ -6,7 +6,7 @@ const AppBuyer = ({ user, logOut, setSellerView }) => (
   <>
     <NavigationBarBuyer setSellerView={setSellerView} />
     <RoutesBuyer user={user} logOut={logOut} setSellerView={setSellerView} />
-    <Redirect to="/events" />
+    <Redirect to="/map" />
   </>
 )
 export default AppBuyer

--- a/client/src/components/BackButtonHeader.js
+++ b/client/src/components/BackButtonHeader.js
@@ -1,8 +1,9 @@
 import Button from "react-bootstrap/Button"
 import Col from "react-bootstrap/Col"
 import Nav from "react-bootstrap/Nav"
+import { Link } from "react-router-dom"
 
-const BackButtonHeader = ({ close }) => (
+const BackButtonHeader = ({ linkTo }) => (
   <Col xs={{ span: 12, offset: 0 }} className="mb-4 text-center">
     <Nav className="py-2">
       <Nav.Item>
@@ -11,7 +12,8 @@ const BackButtonHeader = ({ close }) => (
           size="lg"
           className="mr-1"
           aria-label="Return to previous page"
-          onClick={close}
+          as={Link}
+          to={linkTo}
         >
           <i className="bi bi-arrow-left" />
         </Button>

--- a/client/src/components/EventListItem.js
+++ b/client/src/components/EventListItem.js
@@ -1,9 +1,17 @@
 import Card from "react-bootstrap/Card"
 import EventInfoLabel from "./EventInfoLabel"
+import { Link } from "react-router-dom"
 
 const EventListItem = ({ event }) => {
   return (
-    <Card className="mb-1 py-2 px-2">
+    <Card
+      className="mb-1 py-2 px-2"
+      as={Link}
+      to={{
+        pathname: `/events/${event.id}`,
+        state: { event: event },
+      }}
+    >
       <EventInfoLabel event={event} classes="mb-0" omitDate={true} />
     </Card>
   )

--- a/client/src/components/EventPage.js
+++ b/client/src/components/EventPage.js
@@ -61,10 +61,9 @@ const products = [
 
 const EventPage = (props) => {
   const { eventID } = useParams()
+  console.log("eventID: " + eventID)
 
   const event = props.location.state.event
-
-  console.log("eventID: " + eventID)
 
   return (
     <Row>
@@ -79,13 +78,7 @@ const EventPage = (props) => {
       </Col>
       <Col xs={12} className="mx-auto">
         {products.map((product, index) => (
-          <EventPageListItem
-            product={product}
-            event={event}
-            openProductPage={() => {}}
-            closeProductPage={() => {}}
-            key={index}
-          />
+          <EventPageListItem product={product} event={event} key={index} />
         ))}
       </Col>
     </Row>

--- a/client/src/components/EventPage.js
+++ b/client/src/components/EventPage.js
@@ -3,6 +3,7 @@ import Col from "react-bootstrap/Col"
 import EventInfoLabel from "./EventInfoLabel"
 import EventPageListItem from "./EventPageListItem"
 import BackButtonHeader from "./BackButtonHeader"
+import { useParams } from "react-router-dom"
 
 const products = [
   {
@@ -58,10 +59,20 @@ const products = [
   },
 ]
 
-const EventPage = ({ event, closePage, openProductPage, closeProductPage }) => {
+const EventPage = (props) => {
+  const { eventID } = useParams()
+
+  const event = props.location.state.event
+
+  console.log("eventID: " + eventID)
+
   return (
     <Row>
-      <BackButtonHeader close={closePage} />
+      <BackButtonHeader
+        linkTo={{
+          pathname: "/map",
+        }}
+      />
       <Col xs={12} className="text-center mb-4">
         <h2 className="mb-4">Noutotilaisuus</h2>
         <EventInfoLabel event={event} classes="mb-0" styles={{ fontSize: 16 }} />
@@ -71,8 +82,8 @@ const EventPage = ({ event, closePage, openProductPage, closeProductPage }) => {
           <EventPageListItem
             product={product}
             event={event}
-            openProductPage={openProductPage}
-            closeProductPage={closeProductPage}
+            openProductPage={() => {}}
+            closeProductPage={() => {}}
             key={index}
           />
         ))}

--- a/client/src/components/EventPage.js
+++ b/client/src/components/EventPage.js
@@ -3,7 +3,7 @@ import Col from "react-bootstrap/Col"
 import EventInfoLabel from "./EventInfoLabel"
 import EventPageListItem from "./EventPageListItem"
 import BackButtonHeader from "./BackButtonHeader"
-import { useParams } from "react-router-dom"
+//import { useParams } from "react-router-dom"
 
 const products = [
   {
@@ -60,8 +60,8 @@ const products = [
 ]
 
 const EventPage = (props) => {
-  const { eventID } = useParams()
-  console.log("eventID: " + eventID)
+  //const { eventID } = useParams()
+  //console.log("eventID: " + eventID)
 
   const event = props.location.state.event
 

--- a/client/src/components/EventPageListItem.js
+++ b/client/src/components/EventPageListItem.js
@@ -23,7 +23,7 @@ const EventPageListItem = ({ product, event }) => {
       <Row
         as={Link}
         to={{
-          pathname: `/products/${product.id}`,
+          pathname: `/events/${event.id}/products/${product.id}`,
           state: {
             event: event,
             product: product,
@@ -55,7 +55,7 @@ const EventPageListItem = ({ product, event }) => {
               variant="light"
               as={Link}
               to={{
-                pathname: `/products/${product.id}`,
+                pathname: `/events/${event.id}/products/${product.id}`,
                 state: {
                   event: event,
                   product: product,

--- a/client/src/components/EventPageListItem.js
+++ b/client/src/components/EventPageListItem.js
@@ -5,8 +5,9 @@ import Col from "react-bootstrap/Col"
 import EventPageListButtons from "./EventPageListButtons"
 import { addProductToCart, removeProductFromCart } from "../actions/shoppingCart"
 import { useDispatch } from "react-redux"
+import { Link } from "react-router-dom"
 
-const EventPageListItem = ({ product, event, openProductPage, closeProductPage }) => {
+const EventPageListItem = ({ product, event }) => {
   const dispatch = useDispatch()
 
   const handleAddToCart = (size) => {
@@ -20,9 +21,14 @@ const EventPageListItem = ({ product, event, openProductPage, closeProductPage }
   return (
     <Card className="mb-1 py-2 px-2">
       <Row
-        onClick={() =>
-          openProductPage(product, event, handleAddToCart, handleRemoveFromCart)
-        }
+        as={Link}
+        to={{
+          pathname: `/products/${product.id}`,
+          state: {
+            event: event,
+            product: product,
+          },
+        }}
       >
         <Col xs={4}>
           <Card.Img src="https://via.placeholder.com/50" alt="Generic placeholder" />
@@ -47,9 +53,14 @@ const EventPageListItem = ({ product, event, openProductPage, closeProductPage }
             <Button
               size="lg"
               variant="light"
-              onClick={() =>
-                openProductPage(product, event, handleAddToCart, handleRemoveFromCart)
-              }
+              as={Link}
+              to={{
+                pathname: `/products/${product.id}`,
+                state: {
+                  event: event,
+                  product: product,
+                },
+              }}
             >
               <i className="bi bi-card-list"></i> Eri kokoja
             </Button>

--- a/client/src/components/MapBottomPanel.js
+++ b/client/src/components/MapBottomPanel.js
@@ -1,8 +1,8 @@
 import "./MapPage.css"
 import { forwardRef } from "react"
+import { Link } from "react-router-dom"
 import Button from "react-bootstrap/Button"
 import Card from "react-bootstrap/Card"
-import EventPage from "./EventPage"
 import EventInfoLabel from "./EventInfoLabel"
 
 const MapBottomPanel = forwardRef((props, ref) => {
@@ -10,18 +10,13 @@ const MapBottomPanel = forwardRef((props, ref) => {
     <Card key={index} className="mb-3">
       <EventInfoLabel event={event} classes="mb-0" />
       <Button
-        className="btn btn-primary btn-sm"
+        className="btn btn-primary btn-sm popup-button mt-1"
         variant="success"
-        onClick={() =>
-          props.handleOpenPage(
-            EventPage({
-              event: event,
-              closePage: props.handleClosePage,
-              openProductPage: props.handleOpenProduct,
-              closeProductPage: props.handleCloseProduct,
-            })
-          )
-        }
+        as={Link}
+        to={{
+          pathname: `/events/${event.id}`,
+          state: { event: event },
+        }}
       >
         Siirry tilaisuuteen
       </Button>

--- a/client/src/components/MapPage.css
+++ b/client/src/components/MapPage.css
@@ -31,6 +31,10 @@
   color: rgb(154, 154, 230);
 }
 
+.popup-button {
+  color: white;
+}
+
 .popup-card {
   border-width: 0;
 }

--- a/client/src/components/MapPage.js
+++ b/client/src/components/MapPage.js
@@ -5,11 +5,9 @@ import MapBottomPanel from "./MapBottomPanel"
 import Row from "react-bootstrap/Row"
 import Col from "react-bootstrap/Col"
 import Button from "react-bootstrap/Button"
-import EventPage from "./EventPage"
 import EventInfoLabel from "./EventInfoLabel"
-import SellerPage from "./SellerPage"
-import ProductPage from "./ProductPage"
 import { sellerMarkerHTML, eventMarkerHTML } from "./MapIcons"
+import { Link } from "react-router-dom"
 
 const events = [
   {
@@ -150,7 +148,6 @@ const MapPage = () => {
   const [mapCenter, setMapCenter] = useState([61.59229896416896, 27.256461799773678])
   const [mapBounds, setMapBounds] = useState(null)
   const [mapInstance, setMapInstance] = useState(null)
-  const [openedPage, setOpenedPage] = useState(null)
 
   const firstRender = useRef(true)
   const bottomPanelRef = useRef(null)
@@ -184,39 +181,8 @@ const MapPage = () => {
     setMapCenter(value)
   }
 
-  const handleClosePage = () => {
-    setOpenedPage(null)
-  }
-
-  const handleOpenPage = (page) => {
-    setOpenedPage(page)
-  }
-
   const getMapInstance = (map) => {
     setMapInstance(map)
-  }
-
-  const handleOpenProduct = (product, event, addToCart, removeFromCart) => {
-    setOpenedPage(
-      ProductPage({
-        product: product,
-        event: event,
-        returnToEvent: handleCloseProduct,
-        addToCart: addToCart,
-        removeFromCart: removeFromCart,
-      })
-    )
-  }
-
-  const handleCloseProduct = (event) => {
-    setOpenedPage(
-      EventPage({
-        event: event,
-        closePage: handleClosePage,
-        openProductPage: handleOpenProduct,
-        closeProductPage: handleClosePage,
-      })
-    )
   }
 
   const scrollIntoPanel = () => {
@@ -241,16 +207,11 @@ const MapPage = () => {
         <Button
           className="btn btn-primary btn-sm popup-button mt-1"
           variant="success"
-          onClick={() =>
-            setOpenedPage(
-              EventPage({
-                event: event,
-                closePage: handleClosePage,
-                openProductPage: handleOpenProduct,
-                closeProductPage: handleClosePage,
-              })
-            )
-          }
+          as={Link}
+          to={{
+            pathname: `/events/${event.id}`,
+            state: { event: event },
+          }}
         >
           Siirry tilaisuuteen
         </Button>
@@ -275,11 +236,11 @@ const MapPage = () => {
         <Button
           className="btn btn-primary btn-sm"
           variant="success"
-          onClick={() =>
-            setOpenedPage(
-              SellerPage({ seller: seller, events: events, closePage: handleClosePage })
-            )
-          }
+          as={Link}
+          to={{
+            pathname: `/sellers/${seller.id}`,
+            state: { seller: seller, events: events },
+          }}
         >
           Tuottajan sivulle
         </Button>
@@ -287,9 +248,7 @@ const MapPage = () => {
     </Marker>
   ))
 
-  return openedPage ? (
-    openedPage
-  ) : events ? (
+  return events ? (
     <div className="map-container">
       <MapContainer
         center={mapCenter}
@@ -322,14 +281,7 @@ const MapPage = () => {
             Näytä lista
           </Button>
           <p>Kartan alueelta löytyi {totalVisible} noutopistettä</p>
-          <MapBottomPanel
-            ref={bottomPanelRef}
-            visibleMarkets={visibleMarkets}
-            handleOpenPage={handleOpenPage}
-            handleClosePage={handleClosePage}
-            handleOpenProduct={handleOpenProduct}
-            handleCloseProduct={handleCloseProduct}
-          />
+          <MapBottomPanel ref={bottomPanelRef} visibleMarkets={visibleMarkets} />
         </Col>
       </Row>
     </div>

--- a/client/src/components/MapPage.js
+++ b/client/src/components/MapPage.js
@@ -205,7 +205,8 @@ const MapPage = () => {
       <Popup className="map-popup" autoPan={false}>
         <EventInfoLabel event={event} classes="mb-0 mt-0" styles={{ fontSize: 14 }} />
         <Button
-          className="btn btn-primary btn-sm popup-button mt-1"
+          className="btn btn-success btn-sm popup-button mt-1"
+          style={{ color: "white" }}
           variant="success"
           as={Link}
           to={{
@@ -234,7 +235,8 @@ const MapPage = () => {
         {seller.name} <br />
         {seller.address} <br />
         <Button
-          className="btn btn-primary btn-sm"
+          className="btn btn-success btn-sm popup-button"
+          style={{ color: "white" }}
           variant="success"
           as={Link}
           to={{

--- a/client/src/components/MapPage.js
+++ b/client/src/components/MapPage.js
@@ -241,7 +241,13 @@ const MapPage = () => {
           as={Link}
           to={{
             pathname: `/sellers/${seller.id}`,
-            state: { seller: seller, events: events },
+            state: {
+              seller: seller,
+              events: events,
+              linkTo: {
+                pathname: "/map",
+              },
+            },
           }}
         >
           Tuottajan sivulle

--- a/client/src/components/ProductPage.js
+++ b/client/src/components/ProductPage.js
@@ -2,11 +2,31 @@ import Row from "react-bootstrap/Row"
 import Col from "react-bootstrap/Col"
 import ProductPageListButtons from "./ProductPageListButtons"
 import BackButtonHeader from "./BackButtonHeader"
+import { useDispatch } from "react-redux"
+import { addProductToCart, removeProductFromCart } from "../actions/shoppingCart"
 
-const ProductPage = ({ product, event, returnToEvent, addToCart, removeFromCart }) => {
+const ProductPage = (props) => {
+  const product = props.location.state.product
+  const event = props.location.state.event
+
+  const dispatch = useDispatch()
+
+  const handleAddToCart = (size) => {
+    dispatch(addProductToCart(product, size, event))
+  }
+
+  const handleRemoveFromCart = (size) => {
+    dispatch(removeProductFromCart(product, size, event))
+  }
+
   return (
     <Row className="mx-auto">
-      <BackButtonHeader close={() => returnToEvent(event)} />
+      <BackButtonHeader
+        linkTo={{
+          pathname: `/events/${event.id}`,
+          state: { event: event },
+        }}
+      />
       <Col xs={12} className="d-flex justify-content-start align-items-center mb-4">
         <img src="https://via.placeholder.com/60" alt="Generic placeholder" />{" "}
         <h4 className="mt-2 ml-2">Myyjä X</h4>
@@ -28,8 +48,8 @@ const ProductPage = ({ product, event, returnToEvent, addToCart, removeFromCart 
       {product.sizes.map((size, index) => {
         return (
           <ProductPageListButtons
-            addToCart={addToCart}
-            removeFromCart={removeFromCart}
+            addToCart={handleAddToCart}
+            removeFromCart={handleRemoveFromCart}
             eventID={event.id}
             size={size}
             unit={product.type}

--- a/client/src/components/SellerPage.js
+++ b/client/src/components/SellerPage.js
@@ -6,14 +6,11 @@ import BackButtonHeader from "./BackButtonHeader"
 const SellerPage = (props) => {
   const events = props.location.state.events
   const seller = props.location.state.seller
+  const linkTo = props.location.state.linkTo
 
   return (
     <Row className="mx-auto">
-      <BackButtonHeader
-        linkTo={{
-          pathname: "/map",
-        }}
-      />
+      <BackButtonHeader linkTo={linkTo} />
       <Col xs={12} className="d-flex justify-content-center align-items-center mb-4">
         <img src="https://via.placeholder.com/80" alt="Generic placeholder" />{" "}
       </Col>

--- a/client/src/components/SellerPage.js
+++ b/client/src/components/SellerPage.js
@@ -3,10 +3,17 @@ import Col from "react-bootstrap/Col"
 import EventList from "./EventList"
 import BackButtonHeader from "./BackButtonHeader"
 
-const SellerPage = ({ seller, events, closePage }) => {
+const SellerPage = (props) => {
+  const events = props.location.state.events
+  const seller = props.location.state.seller
+
   return (
     <Row className="mx-auto">
-      <BackButtonHeader close={closePage} />
+      <BackButtonHeader
+        linkTo={{
+          pathname: "/map",
+        }}
+      />
       <Col xs={12} className="d-flex justify-content-center align-items-center mb-4">
         <img src="https://via.placeholder.com/80" alt="Generic placeholder" />{" "}
       </Col>

--- a/client/src/components/navigation/NavigationBarBuyer.js
+++ b/client/src/components/navigation/NavigationBarBuyer.js
@@ -45,7 +45,7 @@ const NavigationBarBuyer = ({ setSellerView }) => {
           <path d="M0 2.5A.5.5 0 0 1 .5 2H2a.5.5 0 0 1 .485.379L2.89 4H14.5a.5.5 0 0 1 .485.621l-1.5 6A.5.5 0 0 1 13 11H4a.5.5 0 0 1-.485-.379L1.61 3H.5a.5.5 0 0 1-.5-.5zM3.14 5l.5 2H5V5H3.14zM6 5v2h2V5H6zm3 0v2h2V5H9zm3 0v2h1.36l.5-2H12zm1.11 3H12v2h.61l.5-2zM11 8H9v2h2V8zM8 8H6v2h2V8zM5 8H3.89l.5 2H5V8zm0 5a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm-2 1a2 2 0 1 1 4 0 2 2 0 0 1-4 0zm9-1a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm-2 1a2 2 0 1 1 4 0 2 2 0 0 1-4 0z" />
         </svg>
       </Nav.Link>
-      <Nav.Link id="events" as={Link} to="/events">
+      <Nav.Link id="events" as={Link} to="/map">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"

--- a/client/src/components/navigation/NavigationBarBuyer.test.js
+++ b/client/src/components/navigation/NavigationBarBuyer.test.js
@@ -1,3 +1,5 @@
+/*
+
 import React from "react";
 import NavigationBarBuyer from "./NavigationBarBuyer";
 import { Link } from "react-router-dom";
@@ -22,6 +24,7 @@ describe("Navigation bar for Buyer", () => {
   const links = wrapper.find(Link);
   const linkURLs = links.map((link) => link.props().to);
 
+
   test("contains 5 links", () => {
     expect(links.length).toBe(5);
   });
@@ -38,3 +41,4 @@ describe("Navigation bar for Buyer", () => {
     expect(sellerView).toBe(null);
   });
 });
+*/

--- a/client/src/components/navigation/NavigationBarBuyer.test.js
+++ b/client/src/components/navigation/NavigationBarBuyer.test.js
@@ -1,12 +1,10 @@
-/*
-
 import React from "react";
 import NavigationBarBuyer from "./NavigationBarBuyer";
 import { Link } from "react-router-dom";
 import { mount } from "enzyme";
 import { BrowserRouter } from "react-router-dom";
 
-const requiredURLs = ["/", "/orders", "/cart", "/events", "/profile"];
+const requiredURLs = ["/", "/orders", "/cart", "/map", "/profile"];
 
 let sellerView = true;
 
@@ -24,7 +22,6 @@ describe("Navigation bar for Buyer", () => {
   const links = wrapper.find(Link);
   const linkURLs = links.map((link) => link.props().to);
 
-
   test("contains 5 links", () => {
     expect(links.length).toBe(5);
   });
@@ -41,4 +38,3 @@ describe("Navigation bar for Buyer", () => {
     expect(sellerView).toBe(null);
   });
 });
-*/

--- a/client/src/components/navigation/RoutesBuyer.js
+++ b/client/src/components/navigation/RoutesBuyer.js
@@ -26,9 +26,9 @@ const RoutesBuyer = ({ user, logOut, setSellerView }) => (
     <Route path="/profile">
       <ProfilePageBuyer user={user} />
     </Route>
-    <Route path="/events/:id" exact component={EventPage}></Route>
-    <Route path="/products/:id" exact component={ProductPage}></Route>
-    <Route path="/sellers/:id" exact component={SellerPage}></Route>
+    <Route path="/events/:eventID" exact component={EventPage}></Route>
+    <Route path="/products/:productID" exact component={ProductPage}></Route>
+    <Route path="/sellers/:sellerID" exact component={SellerPage}></Route>
     <Route>Not found</Route>
   </Switch>
 )

--- a/client/src/components/navigation/RoutesBuyer.js
+++ b/client/src/components/navigation/RoutesBuyer.js
@@ -3,9 +3,11 @@ import { Switch, Route } from "react-router-dom"
 import HomePage from "../HomePage"
 import ProfilePageBuyer from "../profiles/ProfilePageBuyer"
 import MapPage from "../MapPage"
-import Products from "../Products"
 import ShoppingCart from "../ShoppingCart"
 import OrdersBuyers from "../OrdersBuyers"
+import EventPage from "../EventPage"
+import ProductPage from "../ProductPage"
+import SellerPage from "../SellerPage"
 
 const RoutesBuyer = ({ user, logOut, setSellerView }) => (
   <Switch>
@@ -13,16 +15,20 @@ const RoutesBuyer = ({ user, logOut, setSellerView }) => (
       <HomePage logOut={logOut} setSellerView={setSellerView} />
     </Route>
     <Route path="/orders">
-      <OrdersBuyers OrdersBuyers={OrdersBuyers} />
+      <OrdersBuyers />
     </Route>
-    <Route path="/products">
-      <Products products={user.products} />
+    <Route path="/map">
+      <MapPage />
     </Route>
-    <Route path="/events" component={MapPage}></Route>
-    <Route path="/cart" component={ShoppingCart}></Route>
+    <Route path="/cart">
+      <ShoppingCart />
+    </Route>
     <Route path="/profile">
       <ProfilePageBuyer user={user} />
     </Route>
+    <Route path="/events/:id" exact component={EventPage}></Route>
+    <Route path="/products/:id" exact component={ProductPage}></Route>
+    <Route path="/sellers/:id" exact component={SellerPage}></Route>
     <Route>Not found</Route>
   </Switch>
 )

--- a/client/src/components/navigation/RoutesBuyer.js
+++ b/client/src/components/navigation/RoutesBuyer.js
@@ -26,13 +26,9 @@ const RoutesBuyer = ({ user, logOut, setSellerView }) => (
     <Route exact path="/profile">
       <ProfilePageBuyer user={user} />
     </Route>
-    <Route path="/events/:eventID" exact component={EventPage}></Route>
-    <Route
-      path="/events/:eventID/products/:productID"
-      exact
-      component={ProductPage}
-    ></Route>
-    <Route path="/sellers/:sellerID" exact component={SellerPage}></Route>
+    <Route path="/events/:eventID" exact component={EventPage} />
+    <Route path="/events/:eventID/products/:productID" exact component={ProductPage} />
+    <Route path="/sellers/:sellerID" exact component={SellerPage} />
     <Route>Not found</Route>
   </Switch>
 )

--- a/client/src/components/navigation/RoutesBuyer.js
+++ b/client/src/components/navigation/RoutesBuyer.js
@@ -14,20 +14,24 @@ const RoutesBuyer = ({ user, logOut, setSellerView }) => (
     <Route exact path="/">
       <HomePage logOut={logOut} setSellerView={setSellerView} />
     </Route>
-    <Route path="/orders">
+    <Route exact path="/orders">
       <OrdersBuyers />
     </Route>
-    <Route path="/map">
+    <Route exact path="/map">
       <MapPage />
     </Route>
-    <Route path="/cart">
+    <Route exact path="/cart">
       <ShoppingCart />
     </Route>
-    <Route path="/profile">
+    <Route exact path="/profile">
       <ProfilePageBuyer user={user} />
     </Route>
     <Route path="/events/:eventID" exact component={EventPage}></Route>
-    <Route path="/products/:productID" exact component={ProductPage}></Route>
+    <Route
+      path="/events/:eventID/products/:productID"
+      exact
+      component={ProductPage}
+    ></Route>
     <Route path="/sellers/:sellerID" exact component={SellerPage}></Route>
     <Route>Not found</Route>
   </Switch>


### PR DESCRIPTION
Navigation between pages accessible from MapPage now works through Router instead of conditional rendering.

@karvakasa @NinaKWelch Summary of Router functionality using linking to EventPage from MapPage as an example:

Route in RoutesBuyer:
```
<Route path="/events/:eventID" exact component={EventPage} />
```

Passing props to a Routed component in a Link:
```
 <Button
          as={Link}
          to={{
            pathname: `/events/${event.id}`,
            state: { event: event },
          }}
        >
```

Accessing props from the component:
```
const EventPage = (props) => {
  const event = props.location.state.event
```

Accessing URL parameters from the component:
```
import { useParams } from "react-router-dom"
const EventPage = (props) => {
  const { eventID } = useParams()
  console.log("eventID: " + eventID)
```

@ToxPuro to enable link sharing in the future, we should have endpoints for getting individual sellers, events and products in an event: 

```
/sellers/:id
/events/:id
/events/:id/products/:id
```