### PR TITLE
Fix event list duplicates in buyer orders

### DIFF
--- a/client/src/components/OrdersBuyerEventListItem.js
+++ b/client/src/components/OrdersBuyerEventListItem.js
@@ -2,14 +2,14 @@ import Card from "react-bootstrap/Card"
 import EventInfoLabel from "./EventInfoLabel"
 import { Link } from "react-router-dom"
 
-const OrdersBuyerEventListItem = ({ event }) => {
+const OrdersBuyerEventListItem = ({ event, orders }) => {
   return (
     <Card
       className="mb-2 p-2 text-decoration-none text-body"
       as={Link}
       to={{
         pathname: `/orders/buyer/${event.event_id}`,
-        state: { event: event },
+        state: { event: event, orders: orders },
       }}
     >
       <EventInfoLabel

--- a/client/src/components/OrdersBuyerProducts.js
+++ b/client/src/components/OrdersBuyerProducts.js
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom"
 
 const OrdersBuyerProducts = (props) => {
   const event = props.location.state.event
+  const orders = props.location.state.orders
 
   const RenderProducts = (product, index) => {
     return (
@@ -113,18 +114,34 @@ const OrdersBuyerProducts = (props) => {
         />
       </Col>
       <Col xs={12} md={{ span: 10, offset: 1 }} lg={{ span: 8, offset: 2 }}>
-        {event.orders.map(RenderProducts)}
+        {orders.map((order) => {
+          return (
+            <>
+              <p className="mt-4">
+                {order.products[0].seller_name} {order.order_date}
+              </p>
+              {order.products.map((product, index) => {
+                return RenderProducts(product, index)
+              })}
+            </>
+          )
+        })}
       </Col>
       <Col xs={12} md={{ span: 10, offset: 1 }} lg={{ span: 8, offset: 2 }}>
         <Row className="mx-2 justify-content-between">
           <h5>YHTEENSÄ</h5>{" "}
           <h5>
             {Math.round(
-              event.orders.reduce((acc, product) => {
-                if (!product.removed) {
-                  return acc + product.price * product.quantity
-                }
-                return acc
+              orders.reduce((acc, order) => {
+                return (
+                  acc +
+                  order.products.reduce((acc, product) => {
+                    if (!product.removed) {
+                      return acc + product.price * product.quantity
+                    }
+                    return acc
+                  }, 0)
+                )
               }, 0) * 100
             ) / 10000}
             e


### PR DESCRIPTION
- All buyer orders are now listed under a single related event
- Order objects contain order id and date
- Clearer field names for order objects